### PR TITLE
feat: update lidar library for X2

### DIFF
--- a/library/real/lidar_real.py
+++ b/library/real/lidar_real.py
@@ -34,15 +34,47 @@ class LidarReal(Lidar):
             LaserScan, self.__SCAN_TOPIC, self.__scan_callback, qos_profile_sensor_data
         )
 
-        self.__samples = np.empty(0)
-        self.__samples_new = np.empty(0)
+        # 初期化時のサイズ指定
+        # 親クラスで規定されたサイズ(720)のゼロ配列で初期化します。
+        self.__samples = np.zeros(self._NUM_SAMPLES, dtype=np.float32)
+        self.__samples_new = np.zeros(self._NUM_SAMPLES, dtype=np.float32)
 
-    # LIDAR Scan returns value in meters, multiplying by 100 to be processed in cm
-    # LIDAR Scan reversed, flipping order of data entry to correct for CW spin - matches with sim
-    # For RPLidar - replace "inf" with 0 to match sim LIDAR data
     def __scan_callback(self, data):
-        scan_data = np.flip(np.multiply(np.array(data.ranges), 100))
-        self.__samples_new = np.array([0 if str(x) == "inf" else x for x in scan_data])
+        # 1. Convert to numpy array & meters to cm
+        raw_ranges = np.array(data.ranges) * 100
+
+        # 2. Flip to correct for CW spin - matches with sim
+        # X4からX2への移行により左右反転が不要になったためコメントアウト
+        # raw_ranges = np.flip(raw_ranges)
+
+        # === 【修正：オバケ（補間ノイズ）対策】 ===
+        # 「0(なし)」や「inf」と「壁」の間を補間すると、中間の値（近距離の壁）が
+        # 生まれてしまうため、一時的に「遠くの値」に置き換えてから計算します。
+
+        MASK_VALUE = 3000.0  # 30メートル（十分に大きな値）
+        
+        # inf(無限大)、nan(非数)、0(測定不能) をすべて 3000.0 に置換
+        raw_ranges[np.isinf(raw_ranges)] = MASK_VALUE
+        raw_ranges[np.isnan(raw_ranges)] = MASK_VALUE
+        raw_ranges[raw_ranges == 0] = MASK_VALUE
+
+        # 3. Interpolate (Resize) to match sim specification (720 samples)
+        current_len = len(raw_ranges)
+        target_len = self._NUM_SAMPLES  # 720
+
+        if current_len != target_len:
+            # 0から1までの区間を、現在の個数と目標の個数で等分割するインデックスを作成
+            old_indices = np.linspace(0, 1, current_len)
+            new_indices = np.linspace(0, 1, target_len)
+            
+            # 線形補間を実行（この時点では、壁の隣は3000に向かってなだらかに増える）
+            self.__samples_new = np.interp(new_indices, old_indices, raw_ranges).astype(np.float32)
+        else:
+            self.__samples_new = raw_ranges.astype(np.float32)
+
+        # 4. Restore Zeros
+        # 補間が終わったので、遠すぎる値（20メートル以上など）は再び「0（無限遠・測定不能）」に戻してあげる
+        self.__samples_new[self.__samples_new > 2000.0] = 0.0
 
     def __update(self):
         self.__samples = self.__samples_new


### PR DESCRIPTION
X4からX2にモデル変更になったため、ライブラリ用のコードを修正。
主な修正内容としては、X4が360°あたり720点のサンプル数がX2では440程度になるため、このサンプル数の差分を吸収する処理を追加した。
修正されたコードでは、受け取ったデータのサンプル数をベースに線形補間によってデータ数を拡張する。